### PR TITLE
fix for Streetview enabled / disabled not working

### DIFF
--- a/templates/GMapsObject_Fields.ss
+++ b/templates/GMapsObject_Fields.ss
@@ -6,7 +6,7 @@
 	<span class="description">This field is used only to assist with marker placement, it is not shown on the front-end.<br />Please drag the marker to a specific location after typing an address or postcode</span>
 </div>
 <div class="field">
-	<% if EnableStreetView %>
+	<% if SiteConfig.GMapsEnableStreetView %>
 		<div id="GMapsObject_StreetView" style="width: 100%; height: 240px;"></div>
 		<div id="GMapsObject_Map" style="width: 100%; height: 240px;"></div>
 	<% else %>


### PR DESCRIPTION
Streetview is always enabled... found that the variable name is wrong in the template. Should be SiteConfig.GMapsEnableStreetView.